### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": [ "3.14", "3.16", "3.18", "3.20", "3.22" ],
+    "shell-version": [ "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26" ],
     "uuid": "remmina-search-provider@alexmurray.github.com",
     "name": "Remmina Search Provider",
     "url": "https://github.com/alexmurray/remmina-search-provider/",


### PR DESCRIPTION
this plugin is working with gnome shell 3.24 and 3.26 make it compatible with both versions tested on archlinux