### PR TITLE
Wrap displayed text of search results

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -191,6 +191,12 @@ var RemminaSearchProvider = class RemminaSearchProvider_SearchProvider {
         return results.slice(0, max);
     }
 
+    _wrapText(str, maxWidth) {
+        return str.replace(
+            new RegExp(`(?![^\\n]{1,${maxWidth}}$)([^\\n]{1,${maxWidth}})\\s`, 'g'),
+            '$1\n');
+    }
+
     getResultMetas(ids, callback) {
         let metas = [];
         for (let i = 0; i < ids.length; i++) {
@@ -205,10 +211,14 @@ var RemminaSearchProvider = class RemminaSearchProvider_SearchProvider {
             if (session != null) {
                 let prefix = ((session.group && session.group != "") ?
                               ("[" + session.group + "] ") : "");
+                let name = this._wrapText(prefix + session.name + ' (' + session.protocol + ')',
+                                          // TODO: Wrap at max label width
+                                          15);
+
                 metas.push({ id: id,
                              protocol: session.protocol,
                              description: session.server,
-                             name: prefix + session.name + ' (' + session.protocol + ')' });
+                             name: name });
             } else {
                 log("failed to find session with id: " + id);
             }


### PR DESCRIPTION
With this PR, the text of the search results is wrapped around in the overview
so that longer items become distinguishable.

Use case: I have around 100 configured remmina connections at work.  Each one
is in one of four groups and named according the schema `CustomerName, Town,
SystemName, OtherInfo`.  So for example, I might have two connections `John Doe
Inc, Frankfurt/Main, srv-test1-dev, Product 1` and `John Doe Inc,
Frankfurt/Main, srv-prod, Products A & B`.  With the default one-line layout,
the text is truncated after about 15 characters, thus those two entries are
completely indistinguishable.