### PR TITLE
Minor fixes for compatibility.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -33,14 +33,16 @@ const IconGrid = imports.ui.iconGrid;
 const Signals = imports.signals;
 
 // desktop id changed in recent releases
-let ids = ["remmina", "org.remmina.Remmina"];
+let ids = ["org.remmina.Remmina", "remmina", "remmina-file"];
 let remminaApp = null;
 for (let i = 0; !remminaApp && i < ids.length; i++)
 {
-    remminaApp = Shell.AppSystem.get_default().lookup_app(ids[i]);
+    remminaApp = Shell.AppSystem.get_default().lookup_app(ids[i] + ".desktop");
 }
 if (!remminaApp)
+{
     log("Failed to find remmina application");
+}
 
 const emblems = { 'NX': 'remmina-nx',
                   'RDP': 'remmina-rdp',
@@ -157,7 +159,10 @@ var RemminaSearchProvider = class RemminaSearchProvider_SearchProvider {
 
             if (remminaApp) {
                 icon = remminaApp.create_icon_texture(size);
-            } else {
+            }
+
+            if (!icon || !icon.gicon)
+            {
                 // try different icon names
                 let theme = Gtk.IconTheme.get_default();
                 let gicon = null;
@@ -228,7 +233,7 @@ var RemminaSearchProvider = class RemminaSearchProvider_SearchProvider {
 
     activateResult(id, terms) {
         if (remminaApp) {
-            remminaApp.launch(global.get_current_time(), ['-c', id], -1);
+            remminaApp.app_info.launch([Gio.file_new_for_path(id)], null);
         } else {
             Util.spawn(['remmina', '-c', id]);
         }


### PR DESCRIPTION
Great extension, thanks! i had a bit of trouble using it on my system: Ubuntu 19.10 with Remmina 143 (`1.4.5+ppa202005242201.r3604445.d9a00d12~ubuntu19.10.1`) from the [Remmina Next PPA](https://launchpad.net/~remmina-ppa-team/+archive/ubuntu/remmina-next). I tweaked a few things to get it working again.

Basically:
- `org.remmina.Remmina.desktop` seems to be the "proper" desktop file to use. There's no `remmina.desktop` on my system, there's `org.remmina.Remmina.desktop` which contains most of the info, and then a `remmina-file.desktop` (which seems to be more for file-open association purposes) and a `remmina-gnome.desktop` (which is kiosk mode??). So I reordered the IDs searched for at the start.
- `org.remmina.Remmina.desktop` launches a wrapper script which takes a path as an argument **but not with the `-c` flag**
- there are two different launch functions:
  - `Shell.App.launch()` which is really [`shell_app_launch()`](https://developer.gnome.org/shell/stable/shell-shell-app.html#shell-app-launch) which can't take extra arguments, requires info about GPU affinity etc.
  - ``Shell.App.app_info.launch()` which is really [`g_app_info_launch()`](https://developer.gnome.org/gio/stable/GAppInfo.html#g-app-info-launch) which *does* take file parameters. So I changed the invocation to that.

I also found that `Shell.AppSystem.get_default().lookup_app()` requires a `.desktop` extension, so I added that, and that icon creation was always "successful" even if it wasn't really, so I adjusted that logic.

----

The upshot of all this is that I don't quite know which of these are universally-applicable changes and what are system specific. But it does seem like the most recent version of Remmina at least is shipping with the desktop files above, and the other changes are Gnome Shell API related.