### PR TITLE
Add shell version 49 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": [ "45", "46", "47", "48" ],
+    "shell-version": [ "45", "46", "47", "48", "49" ],
     "uuid": "remmina-search-provider@alexmurray.github.com",
     "name": "Remmina Search Provider",
     "url": "https://github.com/alexmurray/remmina-search-provider/",


### PR DESCRIPTION
Tested in Fedora 43